### PR TITLE
feat: Persist `provider_token` to HTTPOnly cookie on SIGNED_IN

### DIFF
--- a/src/nextjs/README.md
+++ b/src/nextjs/README.md
@@ -193,6 +193,52 @@ export const getServerSideProps = withAuthRequired({
 });
 ```
 
+### Server-side data fetching to OAuth APIs using `provider_token`
+
+When using third-party auth providers, sessions are initiated with an additional `provider_token` field which is persisted as an HTTPOnly cookie upon logging in to enabled usage on the server side. The `provider_token` can be used to make API requests to the OAuth provider's API endpoints on behalf of the logged-in user. In the following example, we fetch the user's full profile from the third-party API during SSR using their id and auth token:
+
+```js
+import {
+  User,
+  withAuthRequired,
+  getUser
+} from '@supabase/supabase-auth-helpers/nextjs';
+
+interface Profile {
+  /* ... */
+}
+
+export default function ProtectedPage({
+  user,
+  data
+}: {
+  user: User,
+  profile: Profile
+}) {
+  return <div>Protected content</div>;
+}
+
+export const getServerSideProps = withAuthRequired({
+  redirectTo: '/',
+  async getServerSideProps(ctx) {
+    // Retrieve provider_token from cookies
+    const provider_token = ctx.req.cookies['sb-provider-token'];
+    // Get logged in user's third-party id from metadata
+    const { user } = await getUser(ctx);
+    const userId = user?.user_metadata.provider_id;
+    const profile: Profile = await (
+      await fetch(`https://api.example.com/users/${userId}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${provider_token}`
+        }
+      })
+    ).json();
+    return { props: { profile } };
+  }
+});
+```
+
 ## Protecting API routes
 
 Wrap an API Route to check that the user has a valid session. If they're not logged in the handler will return a

--- a/src/nextjs/handlers/callback.ts
+++ b/src/nextjs/handlers/callback.ts
@@ -11,6 +11,8 @@ export interface HandleCallbackOptions {
   cookieOptions?: CookieOptions;
 }
 
+type AuthCookies = Parameters<typeof setCookies>[2];
+
 export default function handelCallback(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -31,22 +33,30 @@ export default function handelCallback(
       new NextResponseAdapter(res),
       [
         { key: 'access-token', value: session.access_token },
-        { key: 'refresh-token', value: session.refresh_token }
-      ].map((token) => ({
-        name: `${cookieOptions.name}-${token.key}`,
-        value: token.value,
-        domain: cookieOptions.domain,
-        maxAge: cookieOptions.lifetime ?? 0,
-        path: cookieOptions.path,
-        sameSite: cookieOptions.sameSite
-      }))
+        { key: 'refresh-token', value: session.refresh_token },
+        session.provider_token
+          ? { key: 'provider-token', value: session.provider_token }
+          : null
+      ].reduce<AuthCookies>((acc, token) => {
+        if (token) {
+          acc.push({
+            name: `${cookieOptions.name}-${token.key}`,
+            value: token.value,
+            domain: cookieOptions.domain,
+            maxAge: cookieOptions.lifetime ?? 0,
+            path: cookieOptions.path,
+            sameSite: cookieOptions.sameSite
+          });
+        }
+        return acc;
+      }, [])
     );
   }
   if (event === 'SIGNED_OUT') {
     setCookies(
       new NextRequestAdapter(req),
       new NextResponseAdapter(res),
-      ['access-token', 'refresh-token'].map((key) => ({
+      ['access-token', 'refresh-token', 'provider-token'].map((key) => ({
         name: `${cookieOptions.name}-${key}`,
         value: '',
         maxAge: -1

--- a/src/nextjs/handlers/logout.ts
+++ b/src/nextjs/handlers/logout.ts
@@ -32,7 +32,7 @@ export default function handleLogout(
   setCookies(
     new NextRequestAdapter(req),
     new NextResponseAdapter(res),
-    ['access-token', 'refresh-token'].map((key) => ({
+    ['access-token', 'refresh-token', 'provider-token'].map((key) => ({
       name: `${cookieOptions.name}-${key}`,
       value: '',
       maxAge: -1


### PR DESCRIPTION
Closes #40 
Closes supabase/supabase#347

Adds a similar cookie persistence mechanism for `provider_token` to those used for `access_token` and `refresh_token` in [src/nextjs/handlers/callback.ts](https://github.com/supabase-community/supabase-auth-helpers/blob/e188cb903cd532aa438729fda4269bed53b3fff5/src/nextjs/handlers/callback.ts)

Additionally, this cookie is cleared on SIGNED_OUT in both [src/nextjs/handlers/callback.ts](https://github.com/supabase-community/supabase-auth-helpers/blob/e188cb903cd532aa438729fda4269bed53b3fff5/src/nextjs/handlers/callback.ts) and [src/nextjs/handlers/logout.ts](https://github.com/supabase-community/supabase-auth-helpers/blob/e188cb903cd532aa438729fda4269bed53b3fff5/src/nextjs/handlers/logout.ts)

Finally, a usage example was added to [src/nextjs/README.md](https://github.com/supabase-community/supabase-auth-helpers/blob/e188cb903cd532aa438729fda4269bed53b3fff5/src/nextjs/README.md)