### PR TITLE
don't catch errors in user handlers

### DIFF
--- a/src/nextjs/utils/withAuthRequired.ts
+++ b/src/nextjs/utils/withAuthRequired.ts
@@ -91,15 +91,15 @@ export default function withAuthRequired(
           { cookieOptions }
         );
         if (!accessToken) throw new Error('No access token!');
-        await arg(req, res);
       } catch (error) {
         res.status(401).json({
           error: 'not_authenticated',
           description:
-            'The user does not have an active session or is not authenticated'
+          'The user does not have an active session or is not authenticated'
         });
         return;
       }
+      await arg(req, res);
     };
   } else {
     let {
@@ -159,15 +159,8 @@ export default function withAuthRequired(
           throw new Error('No user found!');
         }
 
-        let ret: any = { props: {} };
-        if (getServerSideProps) {
-          ret = await getServerSideProps(context);
-        }
-        return {
-          ...ret,
-          props: { ...ret.props, user: user, accessToken: accessToken }
-        };
       } catch (e) {
+        console.error('The user does not have an active session or is not authenticated', e);
         return {
           redirect: {
             destination: redirectTo,
@@ -175,6 +168,15 @@ export default function withAuthRequired(
           }
         };
       }
+
+      let ret: any = { props: {} };
+      if (getServerSideProps) {
+        ret = await getServerSideProps(context);
+      }
+      return {
+        ...ret,
+        props: { ...ret.props, user: user, accessToken: accessToken }
+      };
     };
   }
 }

--- a/src/nextjs/utils/withMiddlewareAuthRequired.ts
+++ b/src/nextjs/utils/withMiddlewareAuthRequired.ts
@@ -26,6 +26,10 @@ export type WithMiddlewareAuthRequired = (options?: {
 export const withMiddlewareAuthRequired: WithMiddlewareAuthRequired =
   (options: { redirectTo?: string; cookieOptions?: CookieOptions } = {}) =>
   async (req) => {
+    // invoke the main handler first without catching any errors that may result,
+    // then authorize the request before responding
+    const res = NextResponse.next();
+
     try {
       if (
         !process.env.NEXT_PUBLIC_SUPABASE_URL ||
@@ -46,8 +50,6 @@ export const withMiddlewareAuthRequired: WithMiddlewareAuthRequired =
       const cookieOptions = { ...COOKIE_OPTIONS, ...options.cookieOptions };
       const access_token = req.cookies[`${cookieOptions.name!}-access-token`];
       const refresh_token = req.cookies[`${cookieOptions.name!}-refresh-token`];
-
-      const res = NextResponse.next();
 
       const getUser = async (): Promise<{
         user: User | null;


### PR DESCRIPTION
Moves code which invokes logic defined by the library user outside of the try-catch blocks, so that errors in user-written code are handled (or not) as normally expected by Next.

I'm a little unfamiliar with Next middleware so I'm not confident my moving of `NextResponse.next` was quite correct, let me know.