### PR TITLE
Automatically refresh access token before it expires

### DIFF
--- a/src/nextjs/handlers/user.ts
+++ b/src/nextjs/handlers/user.ts
@@ -3,14 +3,23 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { jwtDecoder } from '../../shared/utils/jwt';
 import getUser from '../utils/getUser';
 import { COOKIE_OPTIONS } from '../../shared/utils/constants';
+import { User } from '@supabase/supabase-js';
 
 export interface HandleUserOptions {
   cookieOptions?: CookieOptions;
 }
 
+type UserResponse = {
+  user: User | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  expiresAt: number | null;
+  error?: string;
+};
+
 export default async function handleUser(
   req: NextApiRequest,
-  res: NextApiResponse,
+  res: NextApiResponse<UserResponse>,
   options: HandleUserOptions = {}
 ) {
   try {
@@ -19,9 +28,14 @@ export default async function handleUser(
     }
     const cookieOptions = { ...COOKIE_OPTIONS, ...options.cookieOptions };
     const access_token = req.cookies[`${cookieOptions.name}-access-token`];
+    const refresh_token = req.cookies[`${cookieOptions.name}-refresh-token`];
 
     if (!access_token) {
-      throw new Error('No cookie found!');
+      throw new Error('No access-token cookie found!');
+    }
+
+    if (!refresh_token) {
+      throw new Error('No refresh-token cookie found!');
     }
 
     // Get payload from cached access token.
@@ -54,12 +68,21 @@ export default async function handleUser(
           'This user payload is retrieved from the cached JWT and might be stale. If you need up to date user data, please call the `getUser` method in a server-side context!'
       };
       const mergedUser = { ...user, ...jwtUser };
-      res.status(200).json({ user: mergedUser, accessToken: access_token });
+      res.status(200).json({
+        user: mergedUser,
+        accessToken: access_token,
+        refreshToken: refresh_token,
+        expiresAt: jwtUser.exp
+      });
     }
   } catch (e) {
     const error = e as ApiError;
-    res
-      .status(200)
-      .json({ user: null, accessToken: null, error: error.message });
+    res.status(200).json({
+      user: null,
+      accessToken: null,
+      refreshToken: null,
+      expiresAt: null,
+      error: error.message
+    });
   }
 }

--- a/src/nextjs/utils/getUser.ts
+++ b/src/nextjs/utils/getUser.ts
@@ -22,7 +22,13 @@ export default async function getUser(
     | GetServerSidePropsContext
     | { req: NextApiRequest; res: NextApiResponse },
   options: GetUserOptions = {}
-): Promise<{ user: User | null; accessToken: string | null; error?: string }> {
+): Promise<{
+  user: User | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  expiresAt: number | null;
+  error?: string;
+}> {
   try {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
@@ -78,7 +84,12 @@ export default async function getUser(
             sameSite: cookieOptions.sameSite
           }))
         );
-        return { user: data!.user!, accessToken: data!.access_token };
+        return {
+          user: data!.user!,
+          accessToken: data!.access_token,
+          refreshToken: refresh_token,
+          expiresAt: jwtUser.exp
+        };
       }
     } else {
       const { user, error: getUserError } = await supabase.auth.api.getUser(
@@ -87,11 +98,22 @@ export default async function getUser(
       if (getUserError) {
         throw getUserError;
       }
-      return { user: user!, accessToken: access_token };
+      return {
+        user: user!,
+        accessToken: access_token,
+        refreshToken: refresh_token,
+        expiresAt: jwtUser.exp
+      };
     }
   } catch (e) {
     const error = e as ApiError;
     console.log('Error getting user:', error);
-    return { user: null, accessToken: null, error: error.message };
+    return {
+      user: null,
+      accessToken: null,
+      refreshToken: null,
+      expiresAt: null,
+      error: error.message
+    };
   }
 }


### PR DESCRIPTION
Addresses https://github.com/supabase-community/supabase-auth-helpers/issues/73

Uses a similar timeout mechanism to `gotrue-js`'s `autoRefreshToken` function, but simplified.

With the `refreshToken` available in the frontend after the first commit, it could theoretically be passed to the `supabaseClient.auth` instance so that we can use its `autoRefreshToken` function, but the only current interface for setting the `refreshToken` is `supabaseClient.auth.setSession(refreshToken)`, which triggers a refresh of the token, which we don't want. So the (arguably cleaner) alternative is to handle the refresh within `UserProvider`.