### PR TITLE
update link to @supabase/auth-helpers-nextjs README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of framework specific Auth utilities for working with Supabase.
 
 ## Supported Frameworks
 
-- [Next.js](./src/nextjs/README.md)
+- [Next.js](./packages/nextjs/README.md)
 - [Nuxt - via @nuxtjs/supabase](https://supabase.nuxtjs.org/)
 
 ### Coming soon


### PR DESCRIPTION
The link to the @supabase/auth-helpers-nextjs README on the initial README of the repo is broken. This fixes it.